### PR TITLE
bump to sdk 23

### DIFF
--- a/paralloid/build.gradle
+++ b/paralloid/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 22
+        targetSdkVersion 23
     }
 }
 

--- a/paralloidviews/build.gradle
+++ b/paralloidviews/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
     }
 }
 


### PR DESCRIPTION
As part of https://github.com/Shopify/shopify-android-admin/pull/722 I noticed this dependency was out of sync and it was a pain to have to install the 22 build tools and APIs.

@efung for review
